### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -268,8 +268,7 @@ public class MinijarFilter implements Filter {
             throw ioe;
         } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
             // trap ArrayIndexOutOfBoundsExceptions caused by malformed dependency classes (MSHADE-107)
-            log.warn(dependency
-                    + " could not be analyzed for minimization; dependency is probably malformed.");
+            log.warn(dependency + " could not be analyzed for minimization; dependency is probably malformed.");
         }
 
         return clazzpathUnit;

--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -350,7 +350,3 @@ public class MinijarFilter implements Filter {
         }
     }
 }
-
-
-
-

--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -262,13 +262,13 @@ public class MinijarFilter implements Filter {
             log.warn(dependency.getFile()
                     + " could not be unpacked/read for minimization; dependency is probably malformed.");
             IOException ioe = new IOException(
-                    "Dependency " + dependency.toString() + " in file " + dependency.getFile()
+                    "Dependency " + dependency + " in file " + dependency.getFile()
                             + " could not be unpacked. File is probably corrupt",
                     e);
             throw ioe;
         } catch (ArrayIndexOutOfBoundsException | IllegalArgumentException e) {
             // trap ArrayIndexOutOfBoundsExceptions caused by malformed dependency classes (MSHADE-107)
-            log.warn(dependency.toString()
+            log.warn(dependency
                     + " could not be analyzed for minimization; dependency is probably malformed.");
         }
 
@@ -350,3 +350,7 @@ public class MinijarFilter implements Filter {
         }
     }
 }
+
+
+
+


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-maven-shade-plugin-UnnecessaryToStringCall-65eaea6cba7992f71cb4f0d0f6bee9216213b240-sl:271-el:0-sc:33-ec:0-co:11367-cl:8 -->
<!-- fingerprint:Qodana-maven-shade-plugin-UnnecessaryToStringCall-65eaea6cba7992f71cb4f0d0f6bee9216213b240-sl:265-el:0-sc:48-ec:0-co:10974-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (2)
